### PR TITLE
Improve Hotkey Settings Behaviour

### DIFF
--- a/authorization.js
+++ b/authorization.js
@@ -232,23 +232,6 @@ const openClipbotMainSite = () => {
     return false;
 }
 
-const onHotkeyKeyUp = (event) => {
-    console.log('event: ', event);
-    const keyCode = event.keyCode;
-    const key = event.key;
-    const charCode = event.code;
-  
-    if ((keyCode >= 16 && keyCode <= 18) || keyCode === 91) return;
-  
-    const value = [];
-    event.ctrlKey ? value.push('Control') : null;
-    event.shiftKey ? value.push('Shift') : null;
-    event.isAlt ? value.push('Alt') : null;
-    value.push(key.toUpperCase());
-  
-    document.getElementById('hotkey').value = value.join('+');
-  }
-
 const updateSettings = async (settings) => {
     let url = new URL(`http://localhost:42074/update`);
     // add all fields in settings object to url search params then get /update

--- a/frontend-settings.js
+++ b/frontend-settings.js
@@ -156,22 +156,6 @@ let checkFieldsAreValid = () => {
 };
 // Set interval for querying backend to publish clips
 
-function keyUp(event) {
-  const keyCode = event.keyCode;
-  const key = event.key;
-  const charCode = event.code;
-
-  if ((keyCode >= 16 && keyCode <= 18) || keyCode === 91) return;
-
-  const value = [];
-  event.ctrlKey ? value.push('Control') : null;
-  event.shiftKey ? value.push('Shift') : null;
-  event.isAlt ? value.push('Alt') : null;
-  value.push(key.toUpperCase());
-
-  document.getElementById('hotkey').value = value.join('+');
-}
-
 // Call backend settings endpoint to get current settings
 document.addEventListener('DOMContentLoaded', async function (event) {
   let result = await fetch('http://localhost:42074/settings');

--- a/hotkeyHandler.js
+++ b/hotkeyHandler.js
@@ -1,0 +1,14 @@
+function hotkeyHandler(event) {
+    const keyCode = event.keyCode;
+    const key = event.key;
+
+    if ((keyCode >= 16 && keyCode <= 18) || keyCode === 91 || keyCode === 9) return;
+
+    const value = [];
+    event.ctrlKey ? value.push('Control') : null;
+    event.shiftKey ? value.push('Shift') : null;
+    event.isAlt ? value.push('Alt') : null;
+    value.push(key.toUpperCase());
+
+    document.getElementById('hotkey').value = value.join('+');
+}

--- a/onboarding.html
+++ b/onboarding.html
@@ -32,6 +32,7 @@
     <script src="vertical-helper.js"></script>
     <script src="authorization.js"></script>
     <script src="onboarding.js"></script>
+    <script src="hotkeyHandler.js"></script>
   </head>
   <body id="onboarding">
       <img src='./images/logo-large.png' height='200px' style='margin-top: 20px'/>

--- a/onboarding.js
+++ b/onboarding.js
@@ -139,7 +139,7 @@ const onboardingSteps = [
         input: 'text',
         inputValue: 'F10',
         inputAttributes: {
-            onkeyup: "onHotkeyKeyUp(event)",
+            onkeyup: "hotkeyHandler(event)",
             id: 'hotkey',
         },
         onConfirm: async (hotkey) => {

--- a/settings.html
+++ b/settings.html
@@ -26,6 +26,7 @@
     <link rel="stylesheet" href="electron.css" />
     <script src="uploadClip.js"></script>
     <script src="frontend-settings.js"></script>
+    <script src="hotkeyHandler.js"></script>
   </head>
 
   <body id="settings" class="app">
@@ -68,7 +69,7 @@
           </label>
           <input
             id="hotkey"
-            onkeyup="keyUp(event)"
+            onkeyup="hotkeyHandler(event)"
             placeholder="F10"
             class="form__input settings"
           />


### PR DESCRIPTION
- Ignore TAB key since it automatically overrides current hot key when tabbing in from another element
- refactored both hotkey handling functions into one place

I noticed a slighly annoying behaviour when using the TAB key in the Hashtag input field of the settings window, it tabs into the Hotkey input field (as expected), but then the KeyUp triggers and overrides the current Hotkey with TAB.
Since I don't think that TAB would be used by anyone as a Hotkey, the easiest fix is probably to just disallow it.

I also did some refactoring and removed the duplicate hotkey handling functions into one. I'm new to JS however, so please let me know if that's not the way to do it :)

And last but not least: how do you merge PRs back into your repo? I targeted dev, since I get too many changes otherwise, let me know if I should change that.